### PR TITLE
Separate asset-download script

### DIFF
--- a/bin/download.cmd
+++ b/bin/download.cmd
@@ -1,5 +1,5 @@
 cd bin
 (
-    start "download mdbook" cmd /C "curl -o mdbook.zip https://github.com/rust-lang/mdBook/releases/download/v0.4.28/mdbook-v0.4.28-x86_64-pc-windows-msvc.zip -O -J -L && tar -xf mdbook.zip"
-    start "download katex" cmd /C "curl -o mdbook-katex.zip https://github.com/lzanini/mdbook-katex/releases/download/v0.3.13/mdbook-katex-v0.3.13-x86_64-pc-windows-msvc.zip -O -J -L && tar -xf mdbook-katex.zip"
+    start "download mdbook" cmd /C "curl -o mdbook.zip https://github.com/rust-lang/mdBook/releases/download/v0.4.28/mdbook-v0.4.28-x86_64-pc-windows-msvc.zip -O -J -L && tar -xf mdbook.zip && del mdbook.zip"
+    start "download katex" cmd /C "curl -o mdbook-katex.zip https://github.com/lzanini/mdbook-katex/releases/download/v0.3.13/mdbook-katex-v0.3.13-x86_64-pc-windows-msvc.zip -O -J -L && tar -xf mdbook-katex.zip && del mdbook-katex.zip"
 ) | pause

--- a/bin/download.cmd
+++ b/bin/download.cmd
@@ -1,5 +1,0 @@
-cd bin
-(
-    start "download mdbook" cmd /C "curl -o mdbook.zip https://github.com/rust-lang/mdBook/releases/download/v0.4.28/mdbook-v0.4.28-x86_64-pc-windows-msvc.zip -O -J -L && tar -xf mdbook.zip && del mdbook.zip"
-    start "download katex" cmd /C "curl -o mdbook-katex.zip https://github.com/lzanini/mdbook-katex/releases/download/v0.3.13/mdbook-katex-v0.3.13-x86_64-pc-windows-msvc.zip -O -J -L && tar -xf mdbook-katex.zip && del mdbook-katex.zip"
-) | pause

--- a/build.vbs
+++ b/build.vbs
@@ -1,23 +1,23 @@
-Set fso = CreateObject("Scripting.FileSystemObject")
-folder = fso.GetParentFolderName(Wscript.ScriptFullName)
+Dim fso : Set fso = CreateObject("Scripting.FileSystemObject")
+Dim wsh : Set wsh = CreateObject("Wscript.Shell")
 
 ' download mdbook and mdbook-katex if no executable
-If fso.FileExists("bin\mdbook.exe") AND fso.FileExists("bin\mdbook-katex.exe") Then
+If fso.FileExists("bin/mdbook.exe") AND fso.FileExists("bin/mdbook-katex.exe") Then
 Else
-   result = CreateObject("Wscript.Shell").Run(".\bin\download",1,1)
+   wsh.Run "bin\download.cmd" , 0 , 1
 End If
 
 ' download katex theme if not found
 If fso.FileExists("katex.min.css") Then
 Else
-   result = CreateObject("Wscript.Shell").Run("download_static_css.vbs",1,1)
+   wsh.Run "download_static_css.vbs" , 0 , 1
 End If
 
 ' run mdbook init if no book.toml
 If fso.FileExists("book.toml") Then
 Else
-   result = CreateObject("Wscript.Shell").Run( folder & "/bin/mdbook init" & " --ignore=none --title=''")
+   wsh.Run "bin\mdbook init" & " --ignore=none --title=''" , 1 , 1
 End If
 
 ' build and open book
-result = CreateObject("Wscript.Shell").Run( folder & "/bin/mdbook build" & " --open")
+wsh.Run "bin\mdbook build" & " --open"

--- a/build.vbs
+++ b/build.vbs
@@ -10,27 +10,7 @@ End If
 ' download katex theme if not found
 If fso.FileExists("katex.min.css") Then
 Else
-   CDNROOT = "https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/"
-   CSSPATH = "katex.min.css"
-   CURLCMD = "curl " & CDNROOT & CSSPATH & " -O -J -L"
-   result = CreateObject("Wscript.Shell").Run(CURLCMD,1,True)
-   Set objFileToRead = fso.OpenTextFile("./" & CSSPATH,1)
-   strFileText = objFileToRead.ReadAll()
-   objFileToRead.Close
-   Set objFileToRead = Nothing
-   Set re = New RegExp
-   With re
-   .Pattern    = "url\((fonts\/[^()]+)\)"
-   .Global = True
-   .IgnoreCase = True
-   End With
-   Set colMatch = re.Execute(strFileText)
-   For each objMatch  in colMatch
-      namelen = Len(objMatch.Value)
-      filename = Mid(objMatch.Value, 5,nameLen-5)
-      CURLCMD = "curl -o theme/" & filename & " " & CDNROOT & filename & " -O -J -L"
-      result = CreateObject("Wscript.Shell").Run(CURLCMD,0)
-   Next 
+   result = CreateObject("Wscript.Shell").Run("download_static_css.vbs",1,1)
 End If
 
 ' run mdbook init if no book.toml

--- a/build.vbs
+++ b/build.vbs
@@ -4,7 +4,7 @@ Dim wsh : Set wsh = CreateObject("Wscript.Shell")
 ' download mdbook and mdbook-katex if no executable
 If fso.FileExists("bin/mdbook.exe") AND fso.FileExists("bin/mdbook-katex.exe") Then
 Else
-   wsh.Run "bin\download.cmd" , 0 , 1
+   wsh.Run "download_binaries.cmd" , 0 , 1
 End If
 
 ' download katex theme if not found

--- a/download_binaries.cmd
+++ b/download_binaries.cmd
@@ -1,0 +1,4 @@
+(
+    start "download mdbook" cmd /C "curl --create-dirs -o bin/mdbook.zip https://github.com/rust-lang/mdBook/releases/download/v0.4.28/mdbook-v0.4.28-x86_64-pc-windows-msvc.zip -O -J -L && cd bin && tar -xf mdbook.zip && del mdbook.zip"
+    start "download katex" cmd /C "curl --create-dirs -o bin/mdbook-katex.zip https://github.com/lzanini/mdbook-katex/releases/download/v0.3.13/mdbook-katex-v0.3.13-x86_64-pc-windows-msvc.zip -O -J -L && cd bin && tar -xf mdbook-katex.zip && del mdbook-katex.zip"
+) | pause

--- a/download_static_css.vbs
+++ b/download_static_css.vbs
@@ -43,19 +43,8 @@ Dim wsh : Set wsh = CreateObject("Wscript.Shell")
 
     Set ColMatch = Nothing
 
-    ' Step 3: create folder if it doesn't exist
-    If fso.FolderExists("theme") Then
-       If fso.FolderExists("theme/fonts") Then
-       Else
-          fso.CreateFolder("theme/fonts")
-       End If
-    Else
-       fso.CreateFolder("theme")
-       fso.CreateFolder("theme/fonts")
-    End If
-
-    ' Step 4: download the assets
-    wsh.Run "curl --parallel --config " & CFGPATH , 1 , 1
+    ' Step 3: download the assets
+    wsh.Run "curl --create-dirs --parallel --config " & CFGPATH , 1 , 1
 
 Set wsh = Nothing
 Set fso = Nothing

--- a/download_static_css.vbs
+++ b/download_static_css.vbs
@@ -31,6 +31,10 @@ Dim wsh : Set wsh = CreateObject("Wscript.Shell")
         Set str = Nothing
 
         ' write list to file
+        If fso.FolderExists("bin") Then
+        Else
+           fso.CreateFolder("bin")
+        End If
         Set cfg = fso.OpenTextFile( CFGPATH , 8 , True )
             For each o in colMatch
                 n = Len(o.Value)

--- a/download_static_css.vbs
+++ b/download_static_css.vbs
@@ -1,6 +1,6 @@
 CDNROOT = "https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/"
 CSSPATH = "katex.min.css"
-CFGPATH = "bin/config.txt"
+CFGPATH = "temp.txt"
 
 Dim fso : Set fso = CreateObject("Scripting.FileSystemObject")
 Dim wsh : Set wsh = CreateObject("Wscript.Shell")
@@ -8,7 +8,7 @@ Dim wsh : Set wsh = CreateObject("Wscript.Shell")
     ' Step 1: download katex.min.css
     wsh.Run "curl " & CDNROOT & CSSPATH & " -O -J -L" , 0 , 1
 
-    ' Step 2: list the assets in config.txt
+    ' Step 2: list the assets in temp.txt
     Dim ColMatch
 
         ' build list of urls to download
@@ -31,10 +31,6 @@ Dim wsh : Set wsh = CreateObject("Wscript.Shell")
         Set str = Nothing
 
         ' write list to file
-        If fso.FolderExists("bin") Then
-        Else
-           fso.CreateFolder("bin")
-        End If
         Set cfg = fso.OpenTextFile( CFGPATH , 8 , True )
             For each o in colMatch
                 n = Len(o.Value)
@@ -49,6 +45,9 @@ Dim wsh : Set wsh = CreateObject("Wscript.Shell")
 
     ' Step 3: download the assets
     wsh.Run "curl --create-dirs --parallel --config " & CFGPATH , 1 , 1
+
+    ' Step 4: delete temp.txt
+    fso.DeleteFile(CFGPATH)
 
 Set wsh = Nothing
 Set fso = Nothing

--- a/download_static_css.vbs
+++ b/download_static_css.vbs
@@ -6,7 +6,7 @@ Dim fso : Set fso = CreateObject("Scripting.FileSystemObject")
 Dim wsh : Set wsh = CreateObject("Wscript.Shell")
 
     ' Step 1: download katex.min.css
-    wsh.Run "curl " & CDNROOT & CSSPATH & " -O -J -L" , 1 , True
+    wsh.Run "curl " & CDNROOT & CSSPATH & " -O -J -L" , 0 , 1
 
     ' Step 2: list the assets in config.txt
     Dim ColMatch

--- a/download_static_css.vbs
+++ b/download_static_css.vbs
@@ -1,0 +1,50 @@
+CDNROOT = "https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/"
+CSSPATH = "katex.min.css"
+CFGPATH = "bin/config.txt"
+
+Dim fso : Set fso = CreateObject("Scripting.FileSystemObject")
+Dim wsh : Set wsh = CreateObject("Wscript.Shell")
+
+    ' Step 1: download katex.min.css
+    wsh.Run "curl " & CDNROOT & CSSPATH & " -O -J -L" , 1 , True
+
+    ' Step 2: list the assets in config.txt
+    Dim ColMatch
+
+        ' build list of urls to download
+        Dim str
+            ' read content of katex.min.css
+            Set css = fso.OpenTextFile("./" & CSSPATH, 1)
+                str = css.ReadAll()
+                css.Close
+            Set css = Nothing
+
+            ' build a regex object to match "url(*)"
+            Set rgx = New RegExp
+                With rgx
+                    .Pattern    = "url\((fonts\/[^()]+)\)"
+                    .Global = True
+                    .IgnoreCase = True
+                End With
+                Set colMatch = rgx.Execute(str)
+            Set rgx = Nothing
+        Set str = Nothing
+
+        ' write list to file
+        Set cfg = fso.OpenTextFile( CFGPATH , 8 , True )
+            For each o in colMatch
+                n = Len(o.Value)
+                f = Mid(o.Value, 5,n-5)
+                cfg.WriteLine("url=" & CDNROOT & f)
+                cfg.WriteLine("output=""theme/" & f & """" )
+            Next 
+            cfg.Close
+        Set cfg = Nothing 
+
+    Set ColMatch = Nothing
+
+    ' Step 3: download the assets
+    wsh.Run "curl --parallel --config " & CFGPATH , 1 , 1
+
+Set wsh = Nothing
+Set fso = Nothing

--- a/download_static_css.vbs
+++ b/download_static_css.vbs
@@ -43,7 +43,18 @@ Dim wsh : Set wsh = CreateObject("Wscript.Shell")
 
     Set ColMatch = Nothing
 
-    ' Step 3: download the assets
+    ' Step 3: create folder if it doesn't exist
+    If fso.FolderExists("theme") Then
+       If fso.FolderExists("theme/fonts") Then
+       Else
+          fso.CreateFolder("theme/fonts")
+       End If
+    Else
+       fso.CreateFolder("theme")
+       fso.CreateFolder("theme/fonts")
+    End If
+
+    ' Step 4: download the assets
     wsh.Run "curl --parallel --config " & CFGPATH , 1 , 1
 
 Set wsh = Nothing


### PR DESCRIPTION
Turns out that curl has a built-in concurrent download feature if you supply it with a config file. It also has a flag to create missing directories. Letting curl handle those actions allowed me to decouple them into separate scripts.

- split the font download into a standalone script
- split the binaries download into a standalone script
- removed `.keep` stub, curl can create the fonts folder automatically
- removed `bin` directory, curl can create the bin folder automatically
- binary download now cleans up the zip files after extracting