### PR TITLE
Parallel downloads between css and bin

### DIFF
--- a/build.vbs
+++ b/build.vbs
@@ -11,7 +11,7 @@ End If
 
 ' download katex theme if not found
 If fso.FileExists("katex.min.css") AND fso.FolderExists("theme/fonts") Then
-   haveCss = True
+   haveCSS = True
 End If
 
 If haveExe AND haveCSS Then

--- a/build.vbs
+++ b/build.vbs
@@ -1,16 +1,30 @@
 Dim fso : Set fso = CreateObject("Scripting.FileSystemObject")
 Dim wsh : Set wsh = CreateObject("Wscript.Shell")
 
+haveExe = False
+haveCSS = False
+
 ' download mdbook and mdbook-katex if no executable
 If fso.FileExists("bin/mdbook.exe") AND fso.FileExists("bin/mdbook-katex.exe") Then
-Else
-   wsh.Run "download_binaries.cmd" , 0 , 1
+   haveExe = True
 End If
 
 ' download katex theme if not found
 If fso.FileExists("katex.min.css") AND fso.FolderExists("theme/fonts") Then
+   haveCss = True
+End If
+
+If haveExe AND haveCSS Then
 Else
-   wsh.Run "download_static_css.vbs" , 0 , 1
+   If haveExe Then
+      wsh.Run "download_static_css.vbs" , 0 , 1
+   Else
+      If haveCSS Then
+         wsh.Run "download_binaries.cmd" , 0 , 1
+      Else
+         wsh.Run "cmd /c ""(start /min .\download_binaries.cmd & start .\download_static_css.vbs)|pause""" , 0 , 1
+      End If
+   End If
 End If
 
 ' run mdbook init if no book.toml

--- a/build.vbs
+++ b/build.vbs
@@ -8,7 +8,7 @@ Else
 End If
 
 ' download katex theme if not found
-If fso.FileExists("katex.min.css") Then
+If fso.FileExists("katex.min.css") AND fso.FolderExists("theme/fonts") Then
 Else
    wsh.Run "download_static_css.vbs" , 0 , 1
 End If

--- a/download_binaries.cmd
+++ b/download_binaries.cmd
@@ -2,3 +2,4 @@
     start "download mdbook" cmd /C "curl --create-dirs -o bin/mdbook.zip https://github.com/rust-lang/mdBook/releases/download/v0.4.28/mdbook-v0.4.28-x86_64-pc-windows-msvc.zip -O -J -L && cd bin && tar -xf mdbook.zip && del mdbook.zip"
     start "download katex" cmd /C "curl --create-dirs -o bin/mdbook-katex.zip https://github.com/lzanini/mdbook-katex/releases/download/v0.3.13/mdbook-katex-v0.3.13-x86_64-pc-windows-msvc.zip -O -J -L && cd bin && tar -xf mdbook-katex.zip && del mdbook-katex.zip"
 ) | pause
+exit


### PR DESCRIPTION
The one-click build script can now fire off the font and binary download scripts independently, rather than waiting for the binary download to finish before starting the font download.