### PR TITLE
edited the windows script to create gitignore during init if missing

### DIFF
--- a/build.vbs
+++ b/build.vbs
@@ -30,7 +30,22 @@ End If
 ' run mdbook init if no book.toml
 If fso.FileExists("book.toml") Then
 Else
-   wsh.Run "bin\mdbook init" & " --ignore=none --title=''" , 1 , 1
+   If fso.FileExists(".gitignore") Then
+      init = "bin\mdbook init --title='' --ignore=none"
+      miss = False
+   Else
+      init = "bin\mdbook init --title='' --ignore=git"
+      miss = True
+   End If
+   wsh.Run init , 1 , 1
+   If miss Then
+      Set cfg = fso.OpenTextFile( ".gitignore" , 8 , True )
+      cfg.WriteLine("bin")
+      cfg.WriteLine("katex.min.css")
+      cfg.WriteLine("theme/fonts/KaTeX_*.*")
+      cfg.Close
+      Set cfg = Nothing
+   End If
 End If
 
 ' build and open book

--- a/build.vbs
+++ b/build.vbs
@@ -1,8 +1,9 @@
+Option Explicit
 Dim fso : Set fso = CreateObject("Scripting.FileSystemObject")
 Dim wsh : Set wsh = CreateObject("Wscript.Shell")
 
-haveExe = False
-haveCSS = False
+Dim haveExe : haveExe = False
+Dim haveCSS : haveCSS = False
 
 ' download mdbook and mdbook-katex if no executable
 If fso.FileExists("bin/mdbook.exe") AND fso.FileExists("bin/mdbook-katex.exe") Then
@@ -30,15 +31,19 @@ End If
 ' run mdbook init if no book.toml
 If fso.FileExists("book.toml") Then
 Else
+   ' check if .gitignore already exists
+   Dim init : init = "git"
+   Dim miss : miss = True
    If fso.FileExists(".gitignore") Then
-      init = "bin\mdbook init --title='' --ignore=none"
+      init = "none"
       miss = False
-   Else
-      init = "bin\mdbook init --title='' --ignore=git"
-      miss = True
    End If
-   wsh.Run init , 1 , 1
-   Set cfg = fso.OpenTextFile( "book.toml" , 8 , True )
+
+   ' run mdbook init
+   wsh.Run "bin\mdbook init --title='' --ignore=" & init , 1 , 1
+
+   ' write lines to book.toml
+   Dim cfg : Set cfg = fso.OpenTextFile( "book.toml" , 8 , True )
    cfg.WriteLine("[output.html]")
    cfg.WriteLine("additional-css = [""katex.min.css""]")
    cfg.WriteLine("[preprocessor.katex]")
@@ -46,6 +51,8 @@ Else
    cfg.WriteLine("no-css = true")
    cfg.Close
    Set cfg = Nothing
+
+   ' write lines to .gitignore
    If miss Then
       Set cfg = fso.OpenTextFile( ".gitignore" , 8 , True )
       cfg.WriteLine("bin")
@@ -57,4 +64,4 @@ Else
 End If
 
 ' build and open book
-wsh.Run "bin\mdbook build" & " --open"
+wsh.Run "bin\mdbook build --open"

--- a/build.vbs
+++ b/build.vbs
@@ -38,6 +38,14 @@ Else
       miss = True
    End If
    wsh.Run init , 1 , 1
+   Set cfg = fso.OpenTextFile( "book.toml" , 8 , True )
+   cfg.WriteLine("[output.html]")
+   cfg.WriteLine("additional-css = [""katex.min.css""]")
+   cfg.WriteLine("[preprocessor.katex]")
+   cfg.WriteLine("after = [""links""]")
+   cfg.WriteLine("no-css = true")
+   cfg.Close
+   Set cfg = Nothing
    If miss Then
       Set cfg = fso.OpenTextFile( ".gitignore" , 8 , True )
       cfg.WriteLine("bin")


### PR DESCRIPTION
Made the setup script automatically generate the .gitignore file.

This lets the user copy just the three Windows setup scripts to any folder and run `build.vbs` to start a new mdbook there from scratch.